### PR TITLE
fix: base url for marked plugin

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 type Url = [""] | ["terms", string];
 
 export const getUrl = <K extends Url>(...args: K): string => {
-	return join(import.meta.env.BASE_URL, args.join("/"))
+	return join(
+		process.env.ASTRO_BASE || import.meta.env.BASE_URL,
+		args.join("/"),
+	)
 		.concat("/")
 		.replace(/\/+/g, "/");
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - URL生成ロジックが強化され、`import.meta.env.BASE_URL`が利用できない場合に`process.env.ASTRO_BASE`をフォールバックとして使用するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->