### PR TITLE
feat: remark drawio plugin

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,17 +1,18 @@
 import tailwind from "@astrojs/tailwind";
 import { defineConfig } from "astro/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { remarkDrawioPlugin } from "./src/remark/DrawioPlugin";
 import { remarkTermsLinkPlugin } from "./src/remark/TermsLinkPlugin";
 
 export default defineConfig({
 	site: process.env.ASTRO_SITE,
 	base: process.env.ASTRO_BASE,
 	trailingSlash: "always",
-	integrations: [tailwind()],
+	integrations: [tailwind({ nesting: true })],
 	vite: {
 		plugins: [tsconfigPaths()],
 	},
 	markdown: {
-		remarkPlugins: [remarkTermsLinkPlugin],
+		remarkPlugins: [remarkDrawioPlugin, remarkTermsLinkPlugin],
 	},
 });

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,7 +1,7 @@
 import tailwind from "@astrojs/tailwind";
 import { defineConfig } from "astro/config";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { remarkTermsLinkPlugin } from "./src/utils/remark";
+import { remarkTermsLinkPlugin } from "./src/remark/TermsLinkPlugin";
 
 export default defineConfig({
 	site: process.env.ASTRO_SITE,

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"dependencies": {
 		"@fontsource/ibm-plex-mono": "^5.0.13",
 		"@fontsource/ibm-plex-sans-jp": "^5.0.13",
+		"image-size": "^1.1.1",
 		"unist-util-visit": "^5.0.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fontsource/ibm-plex-sans-jp':
         specifier: ^5.0.13
         version: 5.0.13
+      image-size:
+        specifier: ^1.1.1
+        version: 1.1.1
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1828,6 +1831,11 @@ packages:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
 
+  image-size@1.1.1:
+    resolution: {integrity: sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -2835,6 +2843,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
@@ -5597,6 +5608,10 @@ snapshots:
 
   ignore@5.3.1: {}
 
+  image-size@1.1.1:
+    dependencies:
+      queue: 6.0.2
+
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -6761,6 +6776,10 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   rc-config-loader@4.1.3:
     dependencies:

--- a/src/pages/terms/[slug].astro
+++ b/src/pages/terms/[slug].astro
@@ -24,14 +24,16 @@ const { Content } = await term.render();
 
 <Layout title={term.frontmatter.title}>
 	<article class="prose mx-auto">
-		<h1>{term.frontmatter.title}</h1>
+		<h1>
+			{term.frontmatter.title}
+		</h1>
 		<Content />
 	</article>
 </Layout>
 
 <style>
 :global(.drawio) {
-	@apply grid place-items-center bg-white rounded px-4 py-6 shadow-sm;
+	@apply grid place-items-center bg-white rounded-xl px-4 py-6 shadow-sm border;
 
 	& > :global(img) {
 		@apply m-0 max-w-full;

--- a/src/pages/terms/[slug].astro
+++ b/src/pages/terms/[slug].astro
@@ -28,3 +28,13 @@ const { Content } = await term.render();
 		<Content />
 	</article>
 </Layout>
+
+<style>
+:global(.drawio) {
+	@apply grid place-items-center bg-white rounded px-4 py-6 shadow-sm;
+
+	& > :global(img) {
+		@apply m-0 max-w-full;
+	}
+}
+</style>

--- a/src/remark/DrawioPlugin.ts
+++ b/src/remark/DrawioPlugin.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { RemarkPlugin } from "@astrojs/markdown-remark";
+import sizeOf from "image-size";
+import { is } from "unist-util-is";
+import { visit } from "unist-util-visit";
+import { toUrl } from "../utils/url";
+
+export const remarkDrawioPlugin: RemarkPlugin = () => {
+	return async (tree) => {
+		return visit(tree, "paragraph", (node) => {
+			if (node.children.length !== 1) return;
+
+			const [childNode] = node.children;
+
+			if (!is(childNode, "text")) return;
+
+			const [, id] = childNode.value.match(/^\[\[(\w+)\]\]$/) || [];
+
+			if (!id) return;
+
+			try {
+				const filePath = `/drawio/${id}.drawio.svg`;
+				const { width, height } = sizeOf(
+					fileURLToPath(
+						new URL(join("../../public/", filePath), import.meta.url),
+					),
+				);
+
+				node.data ||= {};
+				node.data.hProperties ||= {};
+				node.data.hProperties.className = ["drawio"];
+				node.children = [
+					{
+						type: "image",
+						data: {
+							hProperties: { width, height },
+						},
+						url: toUrl(filePath),
+					},
+				];
+			} catch (err) {
+				console.error(err);
+
+				node.children = [
+					{
+						type: "html",
+						value: `<!-- [[${id}]] -->`,
+					},
+				];
+			}
+		});
+	};
+};

--- a/src/remark/TermsLinkPlugin.ts
+++ b/src/remark/TermsLinkPlugin.ts
@@ -5,7 +5,7 @@ import matter from "gray-matter";
 import type { PhrasingContent } from "mdast";
 import { is } from "unist-util-is";
 import { visit } from "unist-util-visit";
-import { getUrl } from "./url";
+import { getUrl } from "../utils/url";
 
 const modules = await import.meta.glob("../content/terms/*.md");
 const paths = Object.keys(modules);

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,11 +2,10 @@ import { join } from "node:path";
 
 type Url = [""] | ["terms", string];
 
+export const toUrl = (path: string): string => {
+	return join(process.env.ASTRO_BASE || import.meta.env.BASE_URL, path);
+};
+
 export const getUrl = <K extends Url>(...args: K): string => {
-	return join(
-		process.env.ASTRO_BASE || import.meta.env.BASE_URL,
-		args.join("/"),
-	)
-		.concat("/")
-		.replace(/\/+/g, "/");
+	return toUrl(args.join("/")).concat("/").replace(/\/+/g, "/");
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - MarkdownコンテンツにDraw.io図を埋め込むためのRemarkプラグインを追加しました。

- **改善**
  - Tailwindの統合にネスティングサポートを追加しました。
  - `.drawio`クラスにスタイリングを追加し、グリッドレイアウト、中央配置、背景色、丸角、パディング、シャドウ、ボーダーを適用しました。

- **依存関係**
  - `image-size`パッケージを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->